### PR TITLE
Юникод в тексте сообщения + починил Твиттер-аутентификацию

### DIFF
--- a/Tweets/Tweets/Models/MessageDocument.cs
+++ b/Tweets/Tweets/Models/MessageDocument.cs
@@ -12,7 +12,7 @@ namespace Tweets.Models
         [Column(Name = "userName", DbType = "varchar(100)")]
         public string UserName { get; set; }
 
-        [Column(Name = "text", DbType = "varchar(1000)")]
+        [Column(Name = "text", DbType = "nvarchar(1000)")]
         public string Text { get; set; }
 
         [Column(Name = "createDate", DbType = "datetime")]

--- a/Tweets/Tweets/Tweets.csproj
+++ b/Tweets/Tweets/Tweets.csproj
@@ -41,11 +41,12 @@
     <Reference Include="CorrugatedIron">
       <HintPath>..\packages\CorrugatedIron.1.4.2\lib\net40\CorrugatedIron.dll</HintPath>
     </Reference>
-    <Reference Include="Hammock.ClientProfile">
-      <HintPath>..\packages\TweetSharp.2.3.1\lib\4.0\Hammock.ClientProfile.dll</HintPath>
+    <Reference Include="Hammock">
+      <HintPath>..\packages\TweetSharp-Unofficial.2.3.1.2\lib\4.0\Hammock.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\TweetSharp.2.3.1\lib\4.0\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\TweetSharp-Unofficial.2.3.1.2\lib\4.0\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -66,8 +67,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="TweetSharp">
-      <HintPath>..\packages\TweetSharp.2.3.1\lib\4.0\TweetSharp.dll</HintPath>
+    <Reference Include="TweetSharp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=c148cfba29ed1a4d, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\TweetSharp-Unofficial.2.3.1.2\lib\4.0\TweetSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tweets/Tweets/packages.config
+++ b/Tweets/Tweets/packages.config
@@ -7,5 +7,5 @@
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="structuremap" version="2.6.4.1" targetFramework="net45" />
-  <package id="TweetSharp" version="2.3.1" targetFramework="net45" />
+  <package id="TweetSharp-Unofficial" version="2.3.1.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
У меня не аутентифицировалось через Твиттер, пока не заменил официальный пакет на неофициальный.

http://stackoverflow.com/questions/19676216/tweetsharp-issue-while-getting-the-userprofile-and-timeline
